### PR TITLE
Add lexical-cast to test-tracking.el

### DIFF
--- a/tests/test-tracking.el
+++ b/tests/test-tracking.el
@@ -1,4 +1,4 @@
-;;; Automated tests for tracking.el
+;;; test-tracking.el --- Automated tests for tracking.el -*- lexical-binding: t; -*-
 
 (require 'tracking)
 


### PR DESCRIPTION
Buttercup 1.34 requires `lexical-cast: t` in all files defining buttercup test suites for Emacs >= 29.
It was already documented as a requirement, but was only actually required for some specific functionality.  The introduction of Oclosures for Emacs versions that support them made it a hard requirement.

See also https://bugs.gentoo.org/926083 as reported in https://github.com/jorgenschaefer/emacs-buttercup/issues/243